### PR TITLE
Spread operators in PropTypes declaration crash

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -284,7 +284,13 @@ module.exports = function flowReactPropTypes(babel) {
     const generatedAndExplicitProperties =
       generatedProperties.concat(explicitPropNode.properties)
         .reduce((acc, i) => {
-          acc[i.key.name] = i;
+          if (!!i.key) {
+            acc[i.key.name] = i;
+          }
+          else if (!!i.argument) {
+            acc[i.argument.name] = i;
+          }
+          
           return acc;
         }, {});
 


### PR DESCRIPTION
We have the following code in a React Native project:

```javascript
const sharedPropTypes = {
  name: PropTypes.string,
  adress: PropTypes.string,
  email: PropTypes.string,
};

export class PersonView extends Component {
  props: {
    ...SharedProps,
    age: number,
  };

  static propTypes = {
    ...sharedPropTypes,
    age: PropTypes.number,
  };

  // rest of implementation
}
```

This crasches when trying to transpile it, with the following stack trace.

```shell
TypeError: src/person.js: Cannot read property 'name' of undefined
    at /Users/hmps/dev/mindoktor/app/node_modules/babel-plugin-flow-react-proptypes/lib/index.js:250:17
    at Array.reduce (<anonymous>)
    at mergeExplicitPropTypes (/Users/hmps/dev/mindoktor/app/node_modules/babel-plugin-flow-react-proptypes/lib/index.js:247:98)
    at addAnnotationsToAST (/Users/hmps/dev/mindoktor/app/node_modules/babel-plugin-flow-react-proptypes/lib/index.js:327:34)
    at annotate (/Users/hmps/dev/mindoktor/app/node_modules/babel-plugin-flow-react-proptypes/lib/index.js:381:7)
    at PluginPass.ClassExpressionClassDeclaration (/Users/hmps/dev/mindoktor/app/node_modules/babel-plugin-flow-react-proptypes/lib/index.js:549:9)
    at newFn (/Users/hmps/.npm-packages/lib/node_modules/babel-cli/node_modules/babel-traverse/lib/visitors.js:276:21)
    at NodePath._call (/Users/hmps/.npm-packages/lib/node_modules/babel-cli/node_modules/babel-traverse/lib/path/context.js:76:18)
    at NodePath.call (/Users/hmps/.npm-packages/lib/node_modules/babel-cli/node_modules/babel-traverse/lib/path/context.js:48:17)
    at NodePath.visit (/Users/hmps/.npm-packages/lib/node_modules/babel-cli/node_modules/babel-traverse/lib/path/context.js:105:12)
```

I looked into it a bit and it turns out that `lib/index.js:250` is the `acc[i.key.name] = i;` line in 

```javascript
    var generatedAndExplicitProperties = generatedProperties.concat(explicitPropNode.properties).reduce(function (acc, i) {
      acc[i.key.name] = i;
      return acc;
    }, {});
```

The problem is that the spread operator doesn't have a `key` property. This, for example, is the object passed into the reduce function in our case.

```javascript
Node {
  type: 'SpreadProperty',
  start: 1521,
  end: 1539,
  loc:
   SourceLocation {
     start: Position { line: 61, column: 4 },
     end: Position { line: 61, column: 22 } },
  argument:
   Node {
     type: 'Identifier',
     start: 1524,
     end: 1539,
     loc:
      SourceLocation {
        start: [Object],
        end: [Object],
        identifierName: 'sharedPropTypes' },
     name: 'sharedPropTypes' } }
```

This PR is a (possibly naive) solution to the problem. My knowledge of the inner workings of Babel isn't good enough to realize if this will cause any downstream effects. It seems to works on my machine though :)